### PR TITLE
Update release.yml to use GH_PAT instead of GITHUB_TOKEN for authenti…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,4 @@ jobs:
           tag_name: v${{ github.run_number }}
           name: Release v${{ github.run_number }}
           files: ./CosmosSchemaCloner.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: '${{ secrets.GH_PAT }}'


### PR DESCRIPTION
This pull request updates the release workflow configuration in `.github/workflows/release.yml` to use a personal access token (`GH_PAT`) instead of the default `GITHUB_TOKEN`.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L41-R41): Replaced `GITHUB_TOKEN` with `GH_PAT` for the `token` field in the release workflow to enhance security or permissions.…cation